### PR TITLE
Allow requesting time off for any employee

### DIFF
--- a/employees.js
+++ b/employees.js
@@ -205,10 +205,8 @@ function populateRequestEmployees() {
   });
   if (curId && EMPLOYEES.some(e => String(e.id) === String(curId))) {
     sel.value = curId;
-    if (!isAdmin()) sel.disabled = true;
-  } else {
-    sel.disabled = isAdmin() ? false : (EMPLOYEES.length <= 1 ? false : true);
   }
+  sel.disabled = false;
 }
 
 function toggleTimeInputs() {


### PR DESCRIPTION
## Summary
- Remove employee-selection lock so any user can request time off for any employee

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af999290f8832a9289be8eeded789c