### PR TITLE
Use horizontal timeline for employee schedule

### DIFF
--- a/employees.html
+++ b/employees.html
@@ -8,6 +8,8 @@
     <!-- FullCalendar -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.10/index.global.min.css">
     <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.10/index.global.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/timeline@6.1.10/index.global.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/resource-timeline@6.1.10/index.global.min.js"></script>
     <script src="common.js"></script>
   </head>
   <body>

--- a/employees.html
+++ b/employees.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" href="style.css" />
     <!-- FullCalendar -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.10/index.global.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fullcalendar/timeline@6.1.10/index.global.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fullcalendar/resource-timeline@6.1.10/index.global.min.css">
     <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.10/index.global.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/timeline@6.1.10/index.global.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@fullcalendar/resource-timeline@6.1.10/index.global.min.js"></script>


### PR DESCRIPTION
## Summary
- Switch employee schedule to FullCalendar timeline week view so days appear in a left column and hours across the top
- Load required timeline plugins and split time-off events into per-day segments to render in horizontal bars
- Extend visible hours to 7 AM – 6 PM

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d4a6f188832a8214464ef60212bf