### PR TITLE
Revamp maintenance requests page with modal workflow

### DIFF
--- a/maintenance.css
+++ b/maintenance.css
@@ -1,0 +1,59 @@
+/* Styles specific to the Maintenance Requests page */
+
+.maintenance-layout {
+  display: flex;
+  gap: 20px;
+}
+
+.open-section,
+.closed-section {
+  flex: 1;
+}
+
+.open-section {
+  border-right: 2px solid var(--colour-primary);
+  padding-right: 20px;
+}
+
+.closed-section {
+  padding-left: 20px;
+}
+
+.open-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.request-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.request-list li {
+  background: var(--colour-card-bg);
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 10px;
+  margin-bottom: 10px;
+}
+
+.open-list li {
+  cursor: pointer;
+}
+
+.open-list li:hover {
+  background: var(--colour-background);
+}
+
+form textarea {
+  width: 100%;
+  padding: 10px;
+  margin-top: 4px;
+  box-sizing: border-box;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  font-size: 1rem;
+}

--- a/maintenance.html
+++ b/maintenance.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Maintenance Requests</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="maintenance.css">
 </head>
 <body>
   <!-- Global header -->
@@ -13,30 +14,69 @@
     <h2>Narrows Marina Portal</h2>
   </header>
 
-  <div class="container">
-    <h1>Maintenance Requests</h1>
-    <!-- Form to add a new maintenance request -->
-    <form id="maintenance-form">
-      <label for="maintenance-date">Date
-        <input type="date" id="maintenance-date" required>
-      </label>
-      <label for="maintenance-desc">Description
-        <input type="text" id="maintenance-desc" placeholder="Problem description" required>
-      </label>
-      <label for="maintenance-priority">Priority
-        <select id="maintenance-priority">
-          <option value="Low">Low</option>
-          <option value="Medium">Medium</option>
-          <option value="High">High</option>
-        </select>
-      </label>
-      <button type="submit">Add Request</button>
-    </form>
-
-    <!-- List of maintenance requests -->
-    <ul id="maintenance-list"></ul>
-
+  <div class="container maintenance-layout">
+    <div class="open-section">
+      <div class="open-header">
+        <h1>Open Maintenance Requests</h1>
+        <button id="btn-new-request">Create Request</button>
+      </div>
+      <ul id="open-list" class="request-list open-list"></ul>
+    </div>
+    <div class="closed-section">
+      <h1>Recently Completed Maintenance Requests</h1>
+      <ul id="closed-list" class="request-list"></ul>
+    </div>
     <a href="menu.html" class="back-link">Back to Menu</a>
+  </div>
+
+  <!-- Modal to create a new request -->
+  <div id="request-modal" class="modal" style="display:none;">
+    <div class="modal-content">
+      <h3>Create Maintenance Request</h3>
+      <form id="request-form">
+        <label>Employee Creating Request
+          <select id="req-employee" required></select>
+        </label>
+        <label>Customer Name
+          <input type="text" id="req-customer">
+        </label>
+        <label>Customer Phone Number
+          <input type="tel" id="req-phone">
+        </label>
+        <label>Date
+          <input type="date" id="req-date" required>
+        </label>
+        <label>Description of Issue
+          <textarea id="req-desc" required></textarea>
+        </label>
+        <label>Priority Level
+          <select id="req-priority" required>
+            <option value="High">High</option>
+            <option value="Medium">Medium</option>
+            <option value="Low">Low</option>
+          </select>
+        </label>
+        <label>Issue Location
+          <input type="text" id="req-location" required>
+        </label>
+        <div class="modal-buttons">
+          <button type="button" id="req-cancel">Cancel</button>
+          <button type="submit">Save</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <!-- Modal to view request details -->
+  <div id="detail-modal" class="modal" style="display:none;">
+    <div class="modal-content">
+      <h3>Maintenance Request</h3>
+      <div id="detail-content"></div>
+      <div class="modal-buttons">
+        <button type="button" id="detail-complete">Completed</button>
+        <button type="button" id="detail-close">Close</button>
+      </div>
+    </div>
   </div>
 
   <script src="common.js"></script>

--- a/maintenance.js
+++ b/maintenance.js
@@ -1,45 +1,164 @@
 /*
- * Manage maintenance requests.  Records include a date, description
- * and priority.  Users can add new requests and remove them once
- * resolved.  This script interacts with localStorage via common.js.
+ * Maintenance Requests management
+ * - Displays open and recently completed requests
+ * - Allows creating new requests via modal
+ * - Clicking an open request shows details and option to mark complete
  */
 
 ensureLoggedIn();
 
-const MAINT_KEY = 'maintenanceRequests';
+const OPEN_KEY = 'maintenanceOpenRequests';
+const CLOSED_KEY = 'maintenanceClosedRequests';
 
-function renderMaintenance() {
-  const list = getItems(MAINT_KEY);
-  const ul = document.getElementById('maintenance-list');
+let EMPLOYEES = [];
+let currentIndex = null; // index of request currently viewed
+
+function getOpenList() {
+  return getItems(OPEN_KEY);
+}
+function setOpenList(list) {
+  localStorage.setItem(OPEN_KEY, JSON.stringify(list));
+}
+function getClosedList() {
+  return getItems(CLOSED_KEY);
+}
+function setClosedList(list) {
+  localStorage.setItem(CLOSED_KEY, JSON.stringify(list));
+}
+
+async function loadEmployees() {
+  try {
+    const res = await fetch('data/employees.json', { cache: 'no-store' });
+    if (res.ok) {
+      EMPLOYEES = await res.json();
+    }
+  } catch (e) {
+    console.warn('Employee list load failed', e);
+  }
+}
+
+function populateEmployeeDropdown() {
+  const sel = document.getElementById('req-employee');
+  if (!sel) return;
+  sel.innerHTML = '<option value="" disabled selected>Select employee</option>';
+  EMPLOYEES.forEach(emp => {
+    const opt = document.createElement('option');
+    opt.value = emp.name;
+    opt.textContent = emp.name;
+    sel.appendChild(opt);
+  });
+}
+
+function renderOpen() {
+  const ul = document.getElementById('open-list');
+  const list = getOpenList();
   if (!ul) return;
   ul.innerHTML = '';
-  list.forEach((item, index) => {
+  list.forEach((item, idx) => {
     const li = document.createElement('li');
-    li.textContent = `${item.date}: ${item.description} (Priority: ${item.priority})`;
-    const btn = document.createElement('button');
-    btn.textContent = 'Delete';
-    btn.addEventListener('click', () => {
-      deleteItem(MAINT_KEY, index);
-      renderMaintenance();
-    });
-    li.appendChild(btn);
+    li.textContent = `${item.date} - ${item.description} (${item.priority})`;
+    li.addEventListener('click', () => openDetail(idx));
     ul.appendChild(li);
   });
 }
 
-const form = document.getElementById('maintenance-form');
-if (form) {
-  form.addEventListener('submit', function (e) {
-    e.preventDefault();
-    const newItem = {
-      date: document.getElementById('maintenance-date').value,
-      description: document.getElementById('maintenance-desc').value.trim(),
-      priority: document.getElementById('maintenance-priority').value
-    };
-    saveItem(MAINT_KEY, newItem);
-    form.reset();
-    renderMaintenance();
+function renderClosed() {
+  const ul = document.getElementById('closed-list');
+  const list = getClosedList();
+  if (!ul) return;
+  ul.innerHTML = '';
+  list.forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = `${item.date} - ${item.description} (${item.priority})`;
+    ul.appendChild(li);
   });
 }
 
-renderMaintenance();
+function openRequestModal() {
+  const modal = document.getElementById('request-modal');
+  if (modal) modal.style.display = 'flex';
+}
+function closeRequestModal() {
+  const modal = document.getElementById('request-modal');
+  if (modal) modal.style.display = 'none';
+  const form = document.getElementById('request-form');
+  if (form) form.reset();
+}
+
+function openDetail(index) {
+  const list = getOpenList();
+  const item = list[index];
+  if (!item) return;
+  currentIndex = index;
+  const container = document.getElementById('detail-content');
+  if (container) {
+    container.innerHTML = `
+      <p><strong>Employee:</strong> ${item.employee}</p>
+      ${item.customer ? `<p><strong>Customer:</strong> ${item.customer}</p>` : ''}
+      ${item.phone ? `<p><strong>Phone:</strong> ${item.phone}</p>` : ''}
+      <p><strong>Date:</strong> ${item.date}</p>
+      <p><strong>Description:</strong> ${item.description}</p>
+      <p><strong>Priority:</strong> ${item.priority}</p>
+      <p><strong>Location:</strong> ${item.location}</p>
+    `;
+  }
+  const modal = document.getElementById('detail-modal');
+  if (modal) modal.style.display = 'flex';
+}
+function closeDetail() {
+  const modal = document.getElementById('detail-modal');
+  if (modal) modal.style.display = 'none';
+  currentIndex = null;
+}
+
+function completeCurrent() {
+  if (currentIndex == null) return;
+  const openList = getOpenList();
+  const item = openList.splice(currentIndex, 1)[0];
+  setOpenList(openList);
+  const closed = getClosedList();
+  closed.unshift(item);
+  if (closed.length > 20) closed.length = 20;
+  setClosedList(closed);
+  closeDetail();
+  renderOpen();
+  renderClosed();
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  await loadEmployees();
+  populateEmployeeDropdown();
+  renderOpen();
+  renderClosed();
+
+  const newBtn = document.getElementById('btn-new-request');
+  if (newBtn) newBtn.addEventListener('click', openRequestModal);
+
+  const cancelBtn = document.getElementById('req-cancel');
+  if (cancelBtn) cancelBtn.addEventListener('click', closeRequestModal);
+
+  const form = document.getElementById('request-form');
+  if (form) form.addEventListener('submit', e => {
+    e.preventDefault();
+    const item = {
+      employee: document.getElementById('req-employee').value,
+      customer: document.getElementById('req-customer').value.trim(),
+      phone: document.getElementById('req-phone').value.trim(),
+      date: document.getElementById('req-date').value,
+      description: document.getElementById('req-desc').value.trim(),
+      priority: document.getElementById('req-priority').value,
+      location: document.getElementById('req-location').value.trim()
+    };
+    const list = getOpenList();
+    list.push(item);
+    setOpenList(list);
+    closeRequestModal();
+    renderOpen();
+  });
+
+  const detailClose = document.getElementById('detail-close');
+  if (detailClose) detailClose.addEventListener('click', closeDetail);
+
+  const detailComplete = document.getElementById('detail-complete');
+  if (detailComplete) detailComplete.addEventListener('click', completeCurrent);
+});


### PR DESCRIPTION
## Summary
- Redesign maintenance requests page with open and recently completed sections
- Add modal form for creating requests with employee, customer, date, priority, and location fields
- Enable viewing request details and completing items into a 20-entry history

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b87079e6c4832a8e14b381157a713c