### PR TITLE
Improve maintenance request layout and numbering

### DIFF
--- a/maintenance.css
+++ b/maintenance.css
@@ -10,15 +10,6 @@
   flex: 1;
 }
 
-.open-section {
-  border-right: 2px solid var(--colour-primary);
-  padding-right: 20px;
-}
-
-.closed-section {
-  padding-left: 20px;
-}
-
 .open-header {
   display: flex;
   justify-content: space-between;
@@ -33,19 +24,39 @@
 }
 
 .request-list li {
-  background: var(--colour-card-bg);
-  border: 1px solid #e0e0e0;
+  display: flex;
+  align-items: center;
   border-radius: 8px;
   padding: 10px;
   margin-bottom: 10px;
+  color: #ffffff;
 }
 
-.open-list li {
+.open-section .request-list li {
+  background: var(--colour-secondary);
+}
+
+.closed-section .request-list li {
+  background: var(--colour-primary);
+}
+
+.open-list li.clickable {
   cursor: pointer;
 }
 
-.open-list li:hover {
-  background: var(--colour-background);
+.open-list li.clickable:hover {
+  opacity: 0.9;
+}
+
+.req-number {
+  font-weight: 700;
+  margin-right: 8px;
+  width: 20px;
+  flex-shrink: 0;
+}
+
+.req-text {
+  flex: 1;
 }
 
 form textarea {

--- a/maintenance.html
+++ b/maintenance.html
@@ -26,8 +26,9 @@
       <h1>Recently Completed Maintenance Requests</h1>
       <ul id="closed-list" class="request-list"></ul>
     </div>
-    <a href="menu.html" class="back-link">Back to Menu</a>
   </div>
+
+  <a href="menu.html" class="back-link">Back to Menu</a>
 
   <!-- Modal to create a new request -->
   <div id="request-modal" class="modal" style="display:none;">

--- a/maintenance.js
+++ b/maintenance.js
@@ -54,12 +54,24 @@ function renderOpen() {
   const list = getOpenList();
   if (!ul) return;
   ul.innerHTML = '';
-  list.forEach((item, idx) => {
+  for (let i = 0; i < 10; i++) {
     const li = document.createElement('li');
-    li.textContent = `${item.date} - ${item.description} (${item.priority})`;
-    li.addEventListener('click', () => openDetail(idx));
+    const num = document.createElement('span');
+    num.className = 'req-number';
+    num.textContent = `${i + 1}.`;
+    li.appendChild(num);
+
+    const text = document.createElement('span');
+    text.className = 'req-text';
+    const item = list[i];
+    if (item) {
+      text.textContent = `${formatDate(item.date)} - ${item.description} (${item.priority})`;
+      li.addEventListener('click', () => openDetail(i));
+      li.classList.add('clickable');
+    }
+    li.appendChild(text);
     ul.appendChild(li);
-  });
+  }
 }
 
 function renderClosed() {
@@ -67,11 +79,22 @@ function renderClosed() {
   const list = getClosedList();
   if (!ul) return;
   ul.innerHTML = '';
-  list.forEach(item => {
+  for (let i = 0; i < 10; i++) {
     const li = document.createElement('li');
-    li.textContent = `${item.date} - ${item.description} (${item.priority})`;
+    const num = document.createElement('span');
+    num.className = 'req-number';
+    num.textContent = `${i + 1}.`;
+    li.appendChild(num);
+
+    const text = document.createElement('span');
+    text.className = 'req-text';
+    const item = list[i];
+    if (item) {
+      text.textContent = `${formatDate(item.date)} - ${item.description} (${item.priority})`;
+    }
+    li.appendChild(text);
     ul.appendChild(li);
-  });
+  }
 }
 
 function openRequestModal() {
@@ -162,3 +185,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   const detailComplete = document.getElementById('detail-complete');
   if (detailComplete) detailComplete.addEventListener('click', completeCurrent);
 });
+
+function formatDate(str) {
+  if (!str) return '';
+  const d = new Date(str);
+  if (isNaN(d)) return str;
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}


### PR DESCRIPTION
## Summary
- Move Back to Menu link outside flex container for balanced sections
- Number open and completed request lists with placeholders through ten
- Colorize and style request items with marina palette and shorten dates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b87d3f06cc832aa862b761da8b7020